### PR TITLE
Composer & Contao 4 support

### DIFF
--- a/bepiwikcharts.php
+++ b/bepiwikcharts.php
@@ -152,6 +152,7 @@ class bepiwikcharts extends BackendModule {
     * */
     function JSONload($url, $parameter) {
         $unserializedArray = json_decode($this->readfile($url));
+        $foundContent = [];
         
         for ($i = 0; $i < count($unserializedArray); $i++) {
             foreach ($unserializedArray[$i] as $item => $titel) {
@@ -173,21 +174,23 @@ class bepiwikcharts extends BackendModule {
     function printTable_downloads($inhalte, $cssklasse = "") {
         $tabelle = "<table class=\"" . $cssklasse . "\">";
         $tabelle .= "<tr><th class=\"col0\">" . $GLOBALS['TL_LANG']['be_piwikcharts']['template']['sheet']['table']['downloads_header_domain'] . "</th><th class=\"col1\">" . $GLOBALS['TL_LANG']['be_piwikcharts']['template']['sheet']['table']['downloads_header_file'] . "</th><th class=\"col2\">" . $GLOBALS['TL_LANG']['be_piwikcharts']['template']['sheet']['table']['downloads_header_count'] . "</th></tr>";
-        
-        for ($i = 0; $i <= count($inhalte) / 2; $i = $i + 2) {
-            $maxZeilen = $this->tableMaxRows;
-            
-           if ($maxZeilen > count($inhalte[$i + 1])) {
-                $maxZeilen = count($inhalte[$i + 1]);
-            }
-            
-             for ($j = 0; $j < $maxZeilen; $j++) {
-                $tabelle .= "<tr>";
-                $tabelle .= "<td class=\"col0\">" . $inhalte[$i] . "</td>";
-                $path_parts = pathinfo($inhalte[$i + 1][$j]->label);
-                $tabelle .= "<td class=\"col1\"><a href=\"" . $inhalte[$i + 1][$j]->url . "\" target=\"_blank\" title=\"" . $inhalte[$i + 1][$j]->label . "\">" . $path_parts['basename'] . "</a></td>";
-                $tabelle .= "<td class=\"col2\">" . ($inhalte[$i + 1][$j]->nb_visits) . "</td>";
-                $tabelle .= "</tr>";
+
+        if (!empty($inhalte)) {
+            for ($i = 0; $i <= count($inhalte) / 2; $i = $i + 2) {
+                $maxZeilen = $this->tableMaxRows;
+
+                if ($maxZeilen > count($inhalte[$i + 1])) {
+                    $maxZeilen = count($inhalte[$i + 1]);
+                }
+
+                for ($j = 0; $j < $maxZeilen; $j++) {
+                    $tabelle .= "<tr>";
+                    $tabelle .= "<td class=\"col0\">" . $inhalte[$i] . "</td>";
+                    $path_parts = pathinfo($inhalte[$i + 1][$j]->label);
+                    $tabelle .= "<td class=\"col1\"><a href=\"" . $inhalte[$i + 1][$j]->url . "\" target=\"_blank\" title=\"" . $inhalte[$i + 1][$j]->label . "\">" . $path_parts['basename'] . "</a></td>";
+                    $tabelle .= "<td class=\"col2\">" . ($inhalte[$i + 1][$j]->nb_visits) . "</td>";
+                    $tabelle .= "</tr>";
+                }
             }
         }
 
@@ -489,6 +492,10 @@ class bepiwikcharts extends BackendModule {
                 $GLOBALS['TL_LANG']['be_piwikcharts']['template']['sheet']['table']['visitedPages_header_count']
             ), "data"
         );
+
+        dump($this->buildURL(
+            "Actions.getDownloads", "range", "previous".$this->piwik_period, "&format=json&filter_limit=20&expanded=1&filter_limit=10"
+        ));
         
         // Tabelle: Downloads
         $objTemplate->table_downloads = $this->printTable_downloads(

--- a/bepiwikcharts.php
+++ b/bepiwikcharts.php
@@ -492,10 +492,6 @@ class bepiwikcharts extends BackendModule {
                 $GLOBALS['TL_LANG']['be_piwikcharts']['template']['sheet']['table']['visitedPages_header_count']
             ), "data"
         );
-
-        dump($this->buildURL(
-            "Actions.getDownloads", "range", "previous".$this->piwik_period, "&format=json&filter_limit=20&expanded=1&filter_limit=10"
-        ));
         
         // Tabelle: Downloads
         $objTemplate->table_downloads = $this->printTable_downloads(

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,21 @@
+{
+    "name": "mathcontao/be_piwikcharts",
+    "description": "Extension for the Contao Open Source Content Management System in order to show Matomo statistics directly in the back end.",
+    "type": "contao-module",
+    "license": "LGPL-3.0-or-later",
+    "require": {
+        "php": ">=5.6",
+        "contao/core-bundle": "^2.11 || ^3.0 || ^4.4",
+        "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
+    },
+    "replace": {
+        "contao-legacy/be_piwikcharts": "self.version"
+    },
+    "extra":{
+        "contao":{
+            "sources":{
+                "": "system/modules/be_piwikcharts"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR provides a basic `composer.json` so that this extension is installable in Contao 2, 3 & 4 via Composer. It also fixes an issue for when the Matomo API returns an empty array for downloads.

After merging you need to create an account on [Packagist](https://packagist.org/), enable the [GitHub Hook](https://packagist.org/about) and then [submit the package URL](https://packagist.org/packages/submit).