### PR TITLE
Fix PHP warning

### DIFF
--- a/bepiwikcharts.php
+++ b/bepiwikcharts.php
@@ -27,8 +27,8 @@ class bepiwikcharts extends BackendModule {
     private $chartHeight = 200;
     private $chartWidth = 400;
     private $tableMaxRows = 10;
-    public const DEMO = 0;
-    public const CONNECTED = 1;
+    const DEMO = 0;
+    const CONNECTED = 1;
     private $modus = self::DEMO;      // 0 = Demo, 1 = normal
     private $username = "";
     private $password = "";

--- a/bepiwikcharts.php
+++ b/bepiwikcharts.php
@@ -27,9 +27,9 @@ class bepiwikcharts extends BackendModule {
     private $chartHeight = 200;
     private $chartWidth = 400;
     private $tableMaxRows = 10;
-    const DEMO = 0;
-    const CONNECTED = 1;
-    private $modus = DEMO;      // 0 = Demo, 1 = normal
+    public const DEMO = 0;
+    public const CONNECTED = 1;
+    private $modus = self::DEMO;      // 0 = Demo, 1 = normal
     private $username = "";
     private $password = "";
     private $error = FALSE;


### PR DESCRIPTION
This PR fixes the following PHP warning:

```
Warning: Use of undefined constant DEMO - assumed 'DEMO' (this will throw an Error in a future version of PHP)
```

Otherwise the debug mode cannot be used in the Contao back end (if warnings are not otherwise ignored). This also makes the code more compatible towards PHP 8.0.