### PR TITLE
Fix warnings in PHP 8+

### DIFF
--- a/bepiwikcharts.php
+++ b/bepiwikcharts.php
@@ -52,11 +52,11 @@ class bepiwikcharts extends BackendModule {
             $this->url = $GLOBALS["TL_CONFIG"]['piwikchartsURL'];
             $this->piwik_IDsite = $GLOBALS["TL_CONFIG"]['piwikchartsSiteID'];
             $this->piwik_TOKENauth = $GLOBALS["TL_CONFIG"]['piwikchartsAuthCode'];
-            if (strlen($GLOBALS["TL_CONFIG"]['piwikchartsResolutionWidth']) > 0) {
+            if ($GLOBALS['TL_CONFIG']['piwikchartsResolutionWidth'] ?? null) {
                 $this->resolutionWidthList = $GLOBALS["TL_CONFIG"]['piwikchartsResolutionWidth'];
             }
             
-            if ($GLOBALS["TL_CONFIG"]['piwikchartsPeriod'] != "") {
+            if ($GLOBALS['TL_CONFIG']['piwikchartsPeriod'] ?? null) {
                 $this->piwik_period = intval($GLOBALS["TL_CONFIG"]['piwikchartsPeriod']);
             }
             

--- a/bepiwikcharts.php
+++ b/bepiwikcharts.php
@@ -136,7 +136,7 @@ class bepiwikcharts extends BackendModule {
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, 1);
         curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, $timeout = 5);
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
-        if ($GLOBALS["TL_CONFIG"]['piwikchartsRedirect'] == true) {
+        if (($GLOBALS['TL_CONFIG']['piwikchartsRedirect'] ?? false) === true) {
             curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
         }
         $file = curl_exec($ch);

--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "type": "contao-module",
     "license": "LGPL-3.0-or-later",
     "require": {
-        "php": ">=5.6",
+        "php": ">=7.4",
         "contao/core-bundle": "^4.4",
         "contao-community-alliance/composer-plugin": "~2.4 || ~3.0"
     },


### PR DESCRIPTION
This fixes some warnings in PHP 8+, as there is no default set for various `$GLOBALS['TL_CONFIG']` settings.

However, I think you could omit the `piwikchartsRedirect` setting entirely and always set `curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);`.